### PR TITLE
feat(auth): add public route decorator and update AuthGuard

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -33,13 +33,14 @@ spec:
               memory: "512Mi"
           readinessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: 3000
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: 3000
             initialDelaySeconds: 15
             periodSeconds: 20
+

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -28,6 +28,6 @@ patches:
 images:
 - name: harbor.devostack.com/musclecode/musclecode-backend-main-service
   newName: harbor.devostack.com/musclecode/musclecode-backend-main-service
-  newTag: a7692292fe0c7860c3f8ade213f7c37425e9641e
+  newTag: d93a93780c5776af8fa8242bd706959da0dafcb0
 commonAnnotations:
   image-sha: 67e9e107b614c05fce6fa3b44ed787c7ee70e14c

--- a/src/modules/auth/decorators/public.decorator.ts
+++ b/src/modules/auth/decorators/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/src/modules/auth/guards/auth.guard.ts
+++ b/src/modules/auth/guards/auth.guard.ts
@@ -6,15 +6,27 @@ import {
 } from '@nestjs/common';
 import { AuthService } from '../services/auth.service';
 import { KeycloakService } from '../services/keycloak.service';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+import { Reflector } from '@nestjs/core';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
   constructor(
     private readonly authService: AuthService,
     private readonly keycloakService: KeycloakService,
+    private readonly reflector: Reflector,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true;
+    }
+
     const request = context.switchToHttp().getRequest();
     const authHeader = request.headers.authorization;
 

--- a/src/modules/health/controllers/health.controller.ts
+++ b/src/modules/health/controllers/health.controller.ts
@@ -1,9 +1,11 @@
 import { Controller, Get, HttpStatus } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Public } from 'src/modules/auth/decorators/public.decorator';
 
 @ApiTags('Health')
-@Controller('health')
+@Controller('healthz')
 export class HealthController {
+  @Public()
   @Get()
   @ApiOperation({ summary: 'Check service health' })
   @ApiResponse({


### PR DESCRIPTION
- Create Public decorator to mark routes as publicly accessible
- Modify AuthGuard to skip authentication for public routes
- Apply Public decorator to health check endpoint